### PR TITLE
Allow multiple Error pixels

### DIFF
--- a/vast4.xsd
+++ b/vast4.xsd
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <!--Created with Liquid XML Studio Developer Bundle Edition (Trial) (http://www.liquid-technologies.com)-->
 <xs:schema attributeFormDefault="unqualified"
 		   elementFormDefault="qualified"
@@ -65,7 +65,7 @@
                 name="Error"
                 type="xs:anyURI"
                 minOccurs="0"
-                maxOccurs="1">
+                maxOccurs="unbounded">
 					<xs:annotation>
 						<xs:documentation>
 							Used when there is no ad response. When the ad server does not or cannot return an Ad.
@@ -1100,7 +1100,7 @@
       <xs:element name="Error"
                type="xs:anyURI"
                minOccurs="0"
-               maxOccurs="1">
+               maxOccurs="unbounded">
         <xs:annotation>
           <xs:documentation>URL to request if ad does not play due to error</xs:documentation>
         </xs:annotation>


### PR DESCRIPTION
The spec (https://www.iab.com/wp-content/uploads/2016/04/VAST4.0_Updated_April_2016.pdf) allows multiple Error pixels to be specified, but this is not accepted by the XSD