### PR TITLE
VAST 4.1 Adjustments

### DIFF
--- a/vast_4.1.xsd
+++ b/vast_4.1.xsd
@@ -691,6 +691,51 @@
             </xs:complexType>
           </xs:element>
         </xs:sequence>
+        <xs:attribute name="id" type="xs:string" use="optional">
+          <xs:annotation>
+            <xs:documentation>Optional identifier</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="width" type="xs:integer" use="required">
+          <xs:annotation>
+            <xs:documentation>Pixel dimensions of companion</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="height" type="xs:integer" use="required">
+          <xs:annotation>
+            <xs:documentation>Pixel dimensions of companion</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="expandedWidth" type="xs:integer" use="optional">
+          <xs:annotation>
+            <xs:documentation>Pixel dimensions of expanding nonlinear ad when in expanded state</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="expandedHeight" type="xs:integer" use="optional">
+          <xs:annotation>
+            <xs:documentation>Pixel dimensions of expanding nonlinear ad when in expanded state</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="scalable" type="xs:boolean" use="optional">
+          <xs:annotation>
+            <xs:documentation>Whether it is acceptable to scale the image.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maintainAspectRatio" type="xs:boolean" use="optional">
+          <xs:annotation>
+            <xs:documentation>Whether the ad must have its aspect ratio maintained when scales</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="minSuggestedDuration" type="xs:time" use="optional">
+          <xs:annotation>
+            <xs:documentation>Suggested duration to display non-linear ad, typically for animation to complete. Expressed in standard time format hh:mm:ss</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="apiFramework" type="xs:string" use="optional">
+          <xs:annotation>
+            <xs:documentation>The apiFramework defines the method to use for communication with the nonlinear element</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
@@ -776,7 +821,7 @@
             <xs:documentation>The apiFramework defines the method to use for communication with the companion</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="adSlotID" type="xs:string" use="optional">
+        <xs:attribute name="adSlotId" type="xs:string" use="optional">
           <xs:annotation>
             <xs:documentation>Used to match companion creative to publisher placement areas on the page.</xs:documentation>
           </xs:annotation>
@@ -1037,6 +1082,7 @@
           <xs:simpleContent>
             <xs:extension base="xs:anyURI">
               <xs:attribute name="apiFramework" type="xs:string" use="optional" />
+              <xs:attribute name="type" type="xs:string" use="optional" />
             </xs:extension>
           </xs:simpleContent>
         </xs:complexType>
@@ -1046,6 +1092,7 @@
           <xs:simpleContent>
             <xs:extension base="xs:anyURI">
               <xs:attribute name="apiFramework" type="xs:string" use="optional" />
+              <xs:attribute name="browserOptional" type="xs:boolean" use="optional" />
             </xs:extension>
           </xs:simpleContent>
         </xs:complexType>


### PR DESCRIPTION
- Add NonLinear attributes from VAST 3.0 back
- Change adSlotId back to pre VAST 4.0 version
- Add browserOptional attribute to JavaScriptResource
- Add type attribute to ExecutableResource