### PR TITLE
Support "interactiveStart" event in VAST 4.2 XSD

### DIFF
--- a/vast_4.2.xsd
+++ b/vast_4.2.xsd
@@ -133,6 +133,7 @@
                     <xs:enumeration value="close" />
                     <xs:enumeration value="overlayViewDuration" />
                     <xs:enumeration value="otherAdInteraction" />
+                    <xs:enumeration value="interactiveStart" />
                   </xs:restriction>
                 </xs:simpleType>
               </xs:attribute>


### PR DESCRIPTION
Added VAST 4.2 "interactiveStart" event as a value to TrackingEvents_type enumeration in VAST 4.2 XSD schema.