### PR TITLE
Added `notUsed` as player operation metric for Tracking event attribu…

### DIFF
--- a/vast_4.2.xsd
+++ b/vast_4.2.xsd
@@ -117,6 +117,7 @@
                     <xs:enumeration value="skip" />
                     <xs:enumeration value="playerExpand" />
                     <xs:enumeration value="playerCollapse" />
+                    <xs:enumeration value="notUsed" />
                     <xs:enumeration value="loaded" />
                     <xs:enumeration value="start" />
                     <xs:enumeration value="firstQuartile" />


### PR DESCRIPTION
Added `notUsed` to the list of valid Tracking event attributes.

# 3.14.1 Tracking Event Descriptions (Source: VAST 4.2 PDF)
## Player Operation Metrics (for use in Linear and NonLinear Ads)
`notUsed`: This ad was not and will not be played (e.g. it was prefetched for a particular ad break but was not chosen for playback). This allows ad servers to reuse an ad earlier than otherwise would be possible due to budget/frequency capping. This is a terminal event; no other tracking events should be sent when this is used. Player support is optional and if implemented is provided on a best effort basis as it is not technically possible to fire this event for every unused ad (e.g. when the player itself is terminated before playback).