### PR TITLE
Support for DSA Transparency

### DIFF
--- a/vast4macros/data/macros-data.json
+++ b/vast4macros/data/macros-data.json
@@ -808,6 +808,97 @@
             "description": "Array of the Section ID(s) of the GPP string from GPPSTRING which should be applied. See the GPP Section Information for the list of Section IDs. GPP Section 3 (Header) and 4 (Signal Integrity) do not need to be included.",
             "descriptionformatted": "Array of the Section ID(s) of the GPP string from GPPSTRING which should be applied. See the <a href=\"https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/Section%20Information.md\">GPP Section Information</a> for the list of Section IDs. GPP Section 3 (Header) and 4 (Signal Integrity) do not need to be included.",
             "example": "5,7"
+        },
+        {
+            "id": 57,
+            "name": "DSAREQUIRED",
+            "categoryname": "New Macros",
+            "categoryindex": 1,
+            "datatype": "integer",
+            "type": "integer",
+            "introversion": "Next VAST release",
+            "support": "Optional",
+            "contexts": "VAST request URIs",
+            "values": "see:DSAREQUIRED_values_worksheet",
+            "description": "Flag to indicate if DSA information should be made available. This will signal if the bid request belongs to an Online Platform/VLOP, such that a buyer should respond with DSA Transparency information.",
+            "descriptionformatted": "Flag to indicate if DSA information should be made available. This will signal if the bid request belongs to an Online Platform/VLOP, such that a buyer should respond with DSA Transparency information.",
+            "example": 1
+        },
+        {
+            "id": 58,
+            "name": "DSAPARAMS",
+            "categoryname": "New Macros",
+            "categoryindex": 1,
+            "datatype": "Array<integer>",
+            "type": "Array<integer>",
+            "introversion": "Next VAST release",
+            "support": "Optional",
+            "contexts": "VAST request URIs",
+            "values": "see:DSAPARAMS_values_worksheet",
+            "description": "Array of user parameters applied by the platform or sell-side. See the List and Definitions of User Parameters for a list of possible user parameters.  ",
+            "descriptionformatted": "Array of user parameters applied by the platform or sell-side. See the <a href=\"https://iabeurope.eu/wp-content/uploads/IAB-Europe-DSA-Transparency-Implementation-Guidelines-FINAL.pdf\">List and Definitions of User Parameters</a> for a list of possible user parameters.  ",
+            "example": "1_2"
+        },
+        {
+            "id": 59,
+            "name": "DSAPUBRENDER",
+            "categoryname": "New Macros",
+            "categoryindex": 1,
+            "datatype": "integer",
+            "type": "integer",
+            "introversion": "Next VAST release",
+            "support": "Optional",
+            "contexts": "VAST request URIs",
+            "values": "see:DSAPUBRENDER_values_worksheet",
+            "description": "Signals if the publisher is able to and intends to render an icon or other appropriate user-facing symbol and display the DSA transparency info to the end user.",
+            "descriptionformatted": "Signals if the publisher is able to and intends to render an icon or other appropriate user-facing symbol and display the DSA transparency info to the end user.",
+            "example": 1
+        }
+    ],
+     "DSAPUBRENDER_values": [
+        {
+            "value": 1,
+            "description": "Publisher can't render"
+        },
+        {
+            "value": 2,
+            "description": "Publisher could render depending on adrender"
+        },
+        {
+            "value": 3,
+            "description": "Publisher will render"
+        }
+    ],
+    "DSAPARAMS_values": [
+        {
+            "value": 1,
+            "description": "Profiling"
+        },
+        {
+            "value": 2,
+            "description": "Basic advertising"
+        },
+        {
+            "value": 3,
+            "description": "Precise geolocation"
+        }
+    ],
+    "DSAREQUIRED_values": [
+        {
+            "value": 0,
+            "description": "Not required"
+        },
+        {
+            "value": 1,
+            "description": "Supported, bid responses with or without DSA object will be accepted"
+        },
+        {
+            "value": 2,
+            "description": "Required, bid responses without DSA object will not be accepted"
+        },
+        {
+            "value": 3,
+            "description": "Required, bid responses without DSA object will not be accepted, Publisher is an Online Platform"
         }
     ],
     "GPPSECTIONID_values": [


### PR DESCRIPTION
New macros to support DSA Transparency. 

The Digital Services Act (DSA) was adopted in October 2022, and the date of applicability for Platform companies is 16 February 2024.  Along with the Digital Markets Act (DMA), the DSA is intended to improve the confidence of both private consumers and business users of Online Platforms in the products and services they access via those platforms, as well as the advertising they are exposed to on them, and to ensure a level playing field between platforms.  The DSA lays down transparency obligations in relation to advertising; these obligations apply to Online Platforms, “Very Large Online Platforms” (VLOPs), and “Very Large Online Search Engines” (VLOSEs) as defined by the Digital Services Act.  

Article 26 of the DSA requires Online Platforms to ensure that users have real-time access to certain elements of information about any ad shown to them on an Online Platform:

- That the ad is indeed an ad;
- The identity of the advertiser;
- The identity of the party that financed the ad, if it is different from the advertiser;
- Information about the “main parameters” used to select the ad presented to the end-user;
- Where applicable, information about any means users may have at their disposal to change those main parameters.  

Although the legal obligation to provide the user-facing information disclosures applies to Online Platforms, it is clear that in many advertising scenarios, those platforms will need to rely on third-party vendors for the data that will be required to populate the disclosures.  These macros mimic what is defined in the [DSA Transparency OpenRTB extension](https://github.com/InteractiveAdvertisingBureau/openrtb/blob/main/extensions/community_extensions/dsa_transparency.md). 