### PR TITLE
fix a typo: "gdrp" -> "gdpr"

### DIFF
--- a/vast4macros/data/macros-data.json
+++ b/vast4macros/data/macros-data.json
@@ -944,7 +944,7 @@
             "value": "coppa"
         },
         {
-            "value": "gdrp"
+            "value": "gdpr"
         }
     ],
     "INVENTORYSTATE_values": [


### PR DESCRIPTION
Found this typo when reviewing https://interactiveadvertisingbureau.github.io/vast/vast4macros/vast4-macros-latest.html

![image](https://github.com/user-attachments/assets/31cbf2b3-5d8b-4fe8-bbbc-0a7ad57c96eb)
