### PR TITLE
Fix INVENTORYSTATE example to use valid values

### DIFF
--- a/vast4macros/data/macros-data.json
+++ b/vast4macros/data/macros-data.json
@@ -533,7 +533,7 @@
             "values": "see:INVENTORYSTATE_values_worksheet",
             "description": "List of options indicating attributes of the inventory.",
             "descriptionformatted": "List of options indicating attributes of the inventory.",
-            "example": "<code>autoplayed,fullscreen</code>"
+            "example": "<code>autoplayed,skippable</code>"
         },
         {
             "id": 38,


### PR DESCRIPTION
## Summary
- Fixed the INVENTORYSTATE macro example which incorrectly used "fullscreen" as a value
- "fullscreen" is a PLAYERSTATE value, not an INVENTORYSTATE value
- Changed example from `autoplayed,fullscreen` to `autoplayed,skippable` using valid INVENTORYSTATE values

## Details
The `INVENTORYSTATE_values` in the macros data defines valid values as:
- `skippable`
- `autoplayed`
- `mautoplayed`
- `optin`

The previous example `autoplayed,fullscreen` was incorrect because `fullscreen` belongs to `PLAYERSTATE_values`, not `INVENTORYSTATE_values`.

Fixes #27

## Test plan
- [x] Verified JSON syntax is valid
- [x] Confirmed the new example uses values from INVENTORYSTATE_values

Made with [Cursor](https://cursor.com)